### PR TITLE
Astm Query Handling

### DIFF
--- a/CD4.AstmInterface.DownloaderService/CD4.AstmInterface.DownloaderService.csproj
+++ b/CD4.AstmInterface.DownloaderService/CD4.AstmInterface.DownloaderService.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>dotnet-CD4.AstmInterface.DownloaderService-E8CC3F1D-5A8D-4915-8EA8-0AD4A9E10A7A</UserSecretsId>
+    <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,11 +12,23 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\CD4.DataLibrary\CD4.DataLibrary.csproj" />
+    <ProjectReference Include="..\CD4.ResultsInterface.Common\CD4.ResultsInterface.Common.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Reference Include="SwatInc.Lis.Lis02A2">
+      <HintPath>..\..\..\SwatInc.Lis.Lis01A2\SwatInc.Lis.Lis02A2\bin\Debug\netcoreapp3.1\SwatInc.Lis.Lis02A2.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/CD4.AstmInterface.DownloaderService/CD4.AstmInterface.DownloaderService.csproj
+++ b/CD4.AstmInterface.DownloaderService/CD4.AstmInterface.DownloaderService.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <UserSecretsId>dotnet-CD4.AstmInterface.DownloaderService-E8CC3F1D-5A8D-4915-8EA8-0AD4A9E10A7A</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="5.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/CD4.AstmInterface.DownloaderService/Program.cs
+++ b/CD4.AstmInterface.DownloaderService/Program.cs
@@ -1,3 +1,5 @@
+using CD4.DataLibrary.DataAccess;
+using CD4.ResultsInterface.Common.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -45,6 +47,8 @@ namespace CD4.AstmInterface.DownloaderService
                 .ConfigureServices((hostContext, services) =>
                 {
                     services.AddHostedService<Worker>();
+                    services.AddTransient<IExportService, ExportService>();
+                    services.AddTransient<IOrderDownloadDataAccess, OrderDownloadDataAccess>();
                 })
                 .UseSerilog();
     }

--- a/CD4.AstmInterface.DownloaderService/Program.cs
+++ b/CD4.AstmInterface.DownloaderService/Program.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CD4.AstmInterface.DownloaderService
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
+
+            Log.Logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .CreateLogger();
+
+            try
+            {
+                Log.Warning("Starting up service.");
+                CreateHostBuilder(args).Build().Run();
+
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "There was a problem starting the service.");
+            }
+            finally
+            {
+                Log.Warning("closing!");
+                Log.CloseAndFlush();
+            }
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .UseWindowsService()
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddHostedService<Worker>();
+                })
+                .UseSerilog();
+    }
+}

--- a/CD4.AstmInterface.DownloaderService/Properties/launchSettings.json
+++ b/CD4.AstmInterface.DownloaderService/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+﻿{
+  "profiles": {
+    "CD4.AstmInterface.DownloaderService": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/CD4.AstmInterface.DownloaderService/Worker.cs
+++ b/CD4.AstmInterface.DownloaderService/Worker.cs
@@ -1,4 +1,5 @@
 using CD4.DataLibrary.DataAccess;
+using CD4.ResultsInterface.Common.Models;
 using CD4.ResultsInterface.Common.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -156,17 +157,17 @@ namespace CD4.AstmInterface.DownloaderService
                         .GetAwaiter()
                         .GetResult();
 
-                    if (orders is null) 
+                    if (orders is null)
                     {
                         _logger.LogInformation("No orders downloaded. Writing out empty query response.");
                         ExportEmptyQueryResponse(query.StartingRange.SpecimenID);
-                        continue;  
+                        continue;
                     }
-                    if (orders.Count == 0) 
+                    if (orders.Count == 0)
                     {
                         _logger.LogInformation("No orders downloaded. Writing out empty query response.");
                         ExportEmptyQueryResponse(query.StartingRange.SpecimenID);
-                        continue; 
+                        continue;
                     }
 
                     var jsonOrders = JsonConvert.SerializeObject(orders);
@@ -189,21 +190,21 @@ namespace CD4.AstmInterface.DownloaderService
 
         private void ExportEmptyQueryResponse(string sid)
         {
-            var empty = new
+            var emptyResponse = new List<OrdersDownloadModel>() 
             {
-                Download = "",
-                Sid = sid,
-                SamplePriority = "",
-                TestPriority = "",
-                EpisodeNumber = "",
-                Age = "",
-                Fullname = "",
-                NidPp = "",
-                Birthdate = "",
-                Address = ""
+                new OrdersDownloadModel() 
+                {
+                    Download = "",
+                    Sid = sid,
+                    SamplePriority = false,
+                    TestPriority = false,
+                    EpisodeNumber = "",
+                    Age = "",
+                    Fullname = "",
+                    NidPp = "",
+                    Address = ""
+                }
             };
-
-            var emptyResponse = new List<dynamic>() { empty };
 
             ExportQueryResponse(JsonConvert.SerializeObject(emptyResponse));
             _logger.LogInformation("Exported empty query response.");

--- a/CD4.AstmInterface.DownloaderService/Worker.cs
+++ b/CD4.AstmInterface.DownloaderService/Worker.cs
@@ -1,7 +1,12 @@
+using CD4.DataLibrary.DataAccess;
+using CD4.ResultsInterface.Common.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SwatInc.Lis.Lis02A2;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,27 +17,26 @@ namespace CD4.AstmInterface.DownloaderService
     {
         private readonly ILogger<Worker> _logger;
         private readonly IConfiguration _configuration;
-
+        private readonly IExportService _exportService;
+        private readonly IOrderDownloadDataAccess _orderDownloadDataAccess;
 
         public Worker(ILogger<Worker> logger,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            IExportService exportService,
+            IOrderDownloadDataAccess orderDownloadDataAccess)
         {
             _logger = logger;
             _configuration = configuration;
-
+            _exportService = exportService;
+            _orderDownloadDataAccess = orderDownloadDataAccess;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                var path = _configuration.GetValue<string>("IncomingDirectory");
                 var waitInterval = _configuration.GetValue<int>("WaitIntervalMilliseconds");
-                var queryControlFileExtension = _configuration.GetValue<string>("QueryControlFileExtension");
-                var orderControlFileExtension = _configuration.GetValue<string>("OrderControlFileExtension");
-                var orderControlFileRequired = _configuration.GetValue<bool>("IsOrderControlFileRequired");
                 var queryModeEnabled = _configuration.GetValue<bool>("IsQueryMode");
-                var analyserName = _configuration.GetValue<string>("AnalyserName");
 
                 try
                 {
@@ -40,29 +44,32 @@ namespace CD4.AstmInterface.DownloaderService
                     if (queryModeEnabled)
                     {
                         _logger.LogDebug("Query mode enabled. Looking for pending queries.");
-                        ProcessQueries(path, queryControlFileExtension);
-                        return;
+                        ProcessQueries();
+                    }
+                    else
+                    {
+                        _logger.LogDebug("Query mode disabled. Proceed with download mode");
+                        ProcessOrderDownload();
                     }
 
-                    _logger.LogDebug("Query mode disabled. Proceed with download mode");
-                    ProcessOrderDownload(analyserName);
+                    _logger.LogWarning($"Waiting for {waitInterval} milliseconds.");
+                    await Task.Delay(waitInterval, stoppingToken);
 
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError($"{ex.Message}\n\n{ex.StackTrace}");
                 }
-                finally
-                {
-                    _logger.LogInformation($"Waiting for {waitInterval} milliseconds.");
-                    await Task.Delay(waitInterval, stoppingToken);
-                }
 
             }
         }
 
-        private void ProcessOrderDownload(string analyserName, bool isQueryMode = false, string sid = null)
+        private void ProcessOrderDownload()
         {
+            var analyserName = _configuration.GetValue<string>("DownloadModeAnalyserName");
+            var isQueryMode = _configuration.GetValue<bool>("IsQueryMode");
+            var interfaceUser = _configuration.GetValue<int>("InterfaceUserId");
+
             #region Sanity checks
 
             if (analyserName is null)
@@ -71,28 +78,218 @@ namespace CD4.AstmInterface.DownloaderService
                 return;
             }
 
-            if (isQueryMode && string.IsNullOrEmpty(sid))
+            if (isQueryMode)
             {
-                _logger.LogError($"SID [{sid}] cannot be null with query mode turned on! Ignoring order download.");
+                _logger.LogError($"Query mode turned on! Ignoring download mode path.");
                 return;
             }
 
             #endregion
 
+            try
+            {
+                _logger.LogInformation($"Trying to donwload new orders for analyser: {analyserName} for all samples.");
+                var orders = _orderDownloadDataAccess.DownloadAllOrdersForAnalyserAsync
+                    (analyserName, interfaceUser)
+                    .GetAwaiter()
+                    .GetResult();
 
+                if (orders is null)
+                {
+                    _logger.LogInformation("No orders downloaded available for analyser.");
+                    return;
+                }
+                if (orders.Count == 0)
+                {
+                    _logger.LogInformation("No orders downloaded available for analyser.");
+                    return;
+                }
 
-            throw new NotImplementedException();
+                var jsonOrders = JsonConvert.SerializeObject(orders);
+                _logger.LogInformation($"Orders downloaded...\n{jsonOrders}");
+                ExportQueryResponse(jsonOrders);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("An error occured while trying to download ALL orders for analyser.");
+                _logger.LogError($"{ex.Message}\n{ex.StackTrace}");
+            }
+
         }
 
-        private void ProcessQueries(string path, string controlFileExtension)
+        private void ProcessQueries()
         {
-            string[] files = Directory.GetFiles(path, controlFileExtension);
-            if (files.Length == 0)
+
+            var incomingPath = _configuration.GetValue<string>("IncomingDirectory");
+            var queryControlFileExtension = _configuration.GetValue<string>("QueryControlFileExtension");
+            var InterfaceUserId = _configuration.GetValue<int>("InterfaceUserId");
+
+            _logger.LogInformation("looking for analyser query control files.");
+            string[] controlFiles = Directory.GetFiles(incomingPath, $"*.{queryControlFileExtension}");
+            if (controlFiles.Length == 0)
             {
                 _logger.LogInformation("No incoming queries for processing.");
                 return;
             }
-            _logger.LogInformation($"{files.Length} query file(s) detected for processing.");
+
+            var queryJsonFiles = GetQueryDataFiles(controlFiles);
+
+            _logger.LogInformation($"{queryJsonFiles.Count} query file(s) detected for processing.");
+            _logger.LogDebug("Detected Files...");
+            foreach (var item in queryJsonFiles)
+            {
+                _logger.LogDebug(item);
+            }
+
+            try
+            {
+                _logger.LogInformation("Calling function to parse queries...");
+                var queries = ParseQueries<QueryRecord>(queryJsonFiles);
+                if (queries.Count == 0) { _logger.LogInformation("Parse finction did not return any query records"); return; }
+
+                _logger.LogInformation("Downloading orders for queries...");
+                foreach (var query in queries)
+                {
+                    _logger.LogInformation($"Downloading orders for {query.UserFieldNumberTwo} for SID: {query.StartingRange.SpecimenID}.");
+                    var orders = _orderDownloadDataAccess.DownloadAllAnalyserSpecificOrdersForQueriedSampleAsync
+                        (query.UserFieldNumberTwo, query.StartingRange.SpecimenID, InterfaceUserId)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    if (orders is null) 
+                    {
+                        _logger.LogInformation("No orders downloaded. Writing out empty query response.");
+                        ExportEmptyQueryResponse(query.StartingRange.SpecimenID);
+                        continue;  
+                    }
+                    if (orders.Count == 0) 
+                    {
+                        _logger.LogInformation("No orders downloaded. Writing out empty query response.");
+                        ExportEmptyQueryResponse(query.StartingRange.SpecimenID);
+                        continue; 
+                    }
+
+                    var jsonOrders = JsonConvert.SerializeObject(orders);
+                    _logger.LogInformation($"Orders downloaded...\n{jsonOrders}");
+                    ExportQueryResponse(jsonOrders);
+                }
+
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Query processing failed.");
+                _logger.LogError($"{ex.Message}\n{ex.StackTrace}");
+                return;
+            }
+            finally
+            {
+                //clean up quries
+            }
+        }
+
+        private void ExportEmptyQueryResponse(string sid)
+        {
+            var empty = new
+            {
+                Download = "",
+                Sid = sid,
+                SamplePriority = "",
+                TestPriority = "",
+                EpisodeNumber = "",
+                Age = "",
+                Fullname = "",
+                NidPp = "",
+                Birthdate = "",
+                Address = ""
+            };
+
+            var emptyResponse = new List<dynamic>() { empty };
+
+            ExportQueryResponse(JsonConvert.SerializeObject(emptyResponse));
+            _logger.LogInformation("Exported empty query response.");
+        }
+
+        private void ExportQueryResponse(string jsonOrders)
+        {
+            var orderExportPath = _configuration.GetValue<string>("OrderExportDirectory");
+            var orderDataFileExtension = _configuration.GetValue<string>("OrderDataFileExtension");
+            var orderControlFileExtension = _configuration.GetValue<string>("OrderControlFileExtension");
+
+            _exportService.ExportJsonDataAsync(jsonOrders, orderExportPath, orderDataFileExtension, orderControlFileExtension)
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        private List<string> GetQueryDataFiles(string[] controlFiles)
+        {
+            var queryJsonDataFiles = new List<string>();
+            var queryControlFileExtension = _configuration.GetValue<string>("QueryControlFileExtension");
+            var queryDataFileExtension = _configuration.GetValue<string>("QueryDataFileExtension");
+            var queryBackupFileExtension = _configuration.GetValue<string>("QueryBackupFileExtension");
+
+            foreach (var controlFile in controlFiles)
+            {
+                try
+                {
+                    var controlFileInfo = new FileInfo(controlFile);
+                    var queryDataFileInfo = new FileInfo(controlFileInfo.FullName
+                        .Replace(queryControlFileExtension, queryDataFileExtension));
+                    _logger.LogDebug($"Query File: {queryDataFileInfo.FullName}");
+
+
+                    queryJsonDataFiles.Add(File.ReadAllText(queryDataFileInfo.FullName));
+
+                    _logger.LogInformation($"Deleting control file: {controlFileInfo.Name}.");
+                    if (controlFileInfo.Exists) { controlFileInfo.Delete(); }
+
+                    _logger.LogInformation($"Renaming query file with backup extension {queryBackupFileExtension}");
+                    if (queryDataFileInfo.Exists)
+                    {
+                        queryDataFileInfo.MoveTo
+                            (queryDataFileInfo.FullName
+                                .Replace(queryDataFileExtension, queryBackupFileExtension), true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError($"An error occured while trying to read query data files.\n{ex.Message}\n{ex.StackTrace}");
+                }
+            }
+
+
+            return queryJsonDataFiles;
+        }
+
+        private List<T> ParseQueries<T>(List<string> jsonQueries) where T : new()
+        {
+            if (jsonQueries is null)
+            {
+                throw new ArgumentNullException(nameof(jsonQueries));
+            }
+
+            List<T> queries = new();
+
+            try
+            {
+                _logger.LogInformation("Trying to parse queries...");
+                foreach (var jsonQuery in jsonQueries)
+                {
+                    var query = JsonConvert.DeserializeObject<List<T>>(jsonQuery);
+                    if (query != null)
+                    {
+                        queries.AddRange(query);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Failed to parse query.");
+                _logger.LogError($"{ex.Message}\n{ex.StackTrace}");
+            }
+
+            _logger.LogInformation($"Returning {queries.Count} query record(s)");
+            return queries;
+
         }
     }
 }

--- a/CD4.AstmInterface.DownloaderService/Worker.cs
+++ b/CD4.AstmInterface.DownloaderService/Worker.cs
@@ -1,0 +1,98 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CD4.AstmInterface.DownloaderService
+{
+    public class Worker : BackgroundService
+    {
+        private readonly ILogger<Worker> _logger;
+        private readonly IConfiguration _configuration;
+
+
+        public Worker(ILogger<Worker> logger,
+            IConfiguration configuration)
+        {
+            _logger = logger;
+            _configuration = configuration;
+
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var path = _configuration.GetValue<string>("IncomingDirectory");
+                var waitInterval = _configuration.GetValue<int>("WaitIntervalMilliseconds");
+                var queryControlFileExtension = _configuration.GetValue<string>("QueryControlFileExtension");
+                var orderControlFileExtension = _configuration.GetValue<string>("OrderControlFileExtension");
+                var orderControlFileRequired = _configuration.GetValue<bool>("IsOrderControlFileRequired");
+                var queryModeEnabled = _configuration.GetValue<bool>("IsQueryMode");
+                var analyserName = _configuration.GetValue<string>("AnalyserName");
+
+                try
+                {
+                    //if query mode is enabled, look for query files
+                    if (queryModeEnabled)
+                    {
+                        _logger.LogDebug("Query mode enabled. Looking for pending queries.");
+                        ProcessQueries(path, queryControlFileExtension);
+                        return;
+                    }
+
+                    _logger.LogDebug("Query mode disabled. Proceed with download mode");
+                    ProcessOrderDownload(analyserName);
+
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError($"{ex.Message}\n\n{ex.StackTrace}");
+                }
+                finally
+                {
+                    _logger.LogInformation($"Waiting for {waitInterval} milliseconds.");
+                    await Task.Delay(waitInterval, stoppingToken);
+                }
+
+            }
+        }
+
+        private void ProcessOrderDownload(string analyserName, bool isQueryMode = false, string sid = null)
+        {
+            #region Sanity checks
+
+            if (analyserName is null)
+            {
+                _logger.LogError($"Analyser name [{analyserName}] cannot be null! Ignoring order download.");
+                return;
+            }
+
+            if (isQueryMode && string.IsNullOrEmpty(sid))
+            {
+                _logger.LogError($"SID [{sid}] cannot be null with query mode turned on! Ignoring order download.");
+                return;
+            }
+
+            #endregion
+
+
+
+            throw new NotImplementedException();
+        }
+
+        private void ProcessQueries(string path, string controlFileExtension)
+        {
+            string[] files = Directory.GetFiles(path, controlFileExtension);
+            if (files.Length == 0)
+            {
+                _logger.LogInformation("No incoming queries for processing.");
+                return;
+            }
+            _logger.LogInformation($"{files.Length} query file(s) detected for processing.");
+        }
+    }
+}

--- a/CD4.AstmInterface.DownloaderService/appsettings.Development.json
+++ b/CD4.AstmInterface.DownloaderService/appsettings.Development.json
@@ -14,7 +14,7 @@
   "OrderControlFileExtension": "ook",
   "QueryBackupFileExtension": "sav",
   "IsOrderControlFileRequired": true,
-  "IsQueryMode": false,
+  "IsQueryMode": true,
   "InterfaceUserId": 28,
   "WaitIntervalMilliseconds": 1000,
   "DownloadModeAnalyserName": "QS5-01",

--- a/CD4.AstmInterface.DownloaderService/appsettings.Development.json
+++ b/CD4.AstmInterface.DownloaderService/appsettings.Development.json
@@ -1,22 +1,26 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning",
-      "Microsoft": "Warning",
+      "Default": "Information",
+      "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "IncomingDirectory": "C:\\Export",
-  "QueryControlFileExtension": "*.qok",
+  "OrderDirectory": "C:\\Export",
+  "QueryDataFileExtension": "qrd.json",
+  "QueryControlFileExtension": "qok",
+  "OrderDataFileExtension": "ord",
   "OrderControlFileExtension": "ook",
+  "QueryBackupFileExtension": "sav",
   "IsOrderControlFileRequired": true,
-  "IsQueryMode": true,
-  "AnalyserName": "AlinityCI",
-  "DataFileExtension": ".ojson",
-  "WaitIntervalMilliseconds": 100,
+  "IsQueryMode": false,
+  "InterfaceUserId": 28,
+  "WaitIntervalMilliseconds": 1000,
+  "DownloadModeAnalyserName": "QS5-01",
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Warning"
+      "Default": "Verbose"
     },
     "WriteTo": [
       {
@@ -25,6 +29,13 @@
           "path": "C:\\Logs\\CD4.ResultInterface_Downloader.log",
           "rollingInterval": "Day",
           "retainedFileCountLimit": 15
+        }
+      },
+      {
+        "Name": "Console",
+        "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} <s:{SourceContext}>{NewLine}{Exception}"
         }
       }
     ]

--- a/CD4.AstmInterface.DownloaderService/appsettings.Development.json
+++ b/CD4.AstmInterface.DownloaderService/appsettings.Development.json
@@ -1,0 +1,32 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "IncomingDirectory": "C:\\Export",
+  "QueryControlFileExtension": "*.qok",
+  "OrderControlFileExtension": "ook",
+  "IsOrderControlFileRequired": true,
+  "IsQueryMode": true,
+  "AnalyserName": "AlinityCI",
+  "DataFileExtension": ".ojson",
+  "WaitIntervalMilliseconds": 100,
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Warning"
+    },
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "C:\\Logs\\CD4.ResultInterface_Downloader.log",
+          "rollingInterval": "Day",
+          "retainedFileCountLimit": 15
+        }
+      }
+    ]
+  }
+}

--- a/CD4.AstmInterface.DownloaderService/appsettings.json
+++ b/CD4.AstmInterface.DownloaderService/appsettings.json
@@ -14,7 +14,7 @@
   "OrderControlFileExtension": "ook",
   "QueryBackupFileExtension": "sav",
   "IsOrderControlFileRequired": true,
-  "IsQueryMode": false,
+  "IsQueryMode": true,
   "InterfaceUserId": 28,
   "WaitIntervalMilliseconds": 1000,
   "DownloadModeAnalyserName": "QS5-01",

--- a/CD4.AstmInterface.DownloaderService/appsettings.json
+++ b/CD4.AstmInterface.DownloaderService/appsettings.json
@@ -1,0 +1,32 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "IncomingDirectory": "C:\\Export",
+  "QueryControlFileExtension": "*.qok",
+  "OrderControlFileExtension": "ook",
+  "IsOrderControlFileRequired": true,
+  "IsQueryMode": true,
+  "AnalyserName": "AlinityCI",
+  "DataFileExtension": ".ojson",
+  "WaitIntervalMilliseconds": 100,
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Warning"
+    },
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "C:\\Logs\\CD4.ResultInterface_Downloader.log",
+          "rollingInterval": "Day",
+          "retainedFileCountLimit": 15
+        }
+      }
+    ]
+  }
+}

--- a/CD4.AstmInterface.DownloaderService/appsettings.json
+++ b/CD4.AstmInterface.DownloaderService/appsettings.json
@@ -1,22 +1,26 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning",
-      "Microsoft": "Warning",
+      "Default": "Information",
+      "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "IncomingDirectory": "C:\\Export",
-  "QueryControlFileExtension": "*.qok",
+  "OrderExportDirectory": "C:\\Export",
+  "QueryDataFileExtension": "qrd.json",
+  "QueryControlFileExtension": "qok",
+  "OrderDataFileExtension": "ord",
   "OrderControlFileExtension": "ook",
+  "QueryBackupFileExtension": "sav",
   "IsOrderControlFileRequired": true,
-  "IsQueryMode": true,
-  "AnalyserName": "AlinityCI",
-  "DataFileExtension": ".ojson",
-  "WaitIntervalMilliseconds": 100,
+  "IsQueryMode": false,
+  "InterfaceUserId": 28,
+  "WaitIntervalMilliseconds": 1000,
+  "DownloadModeAnalyserName": "QS5-01",
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Warning"
+      "Default": "Verbose"
     },
     "WriteTo": [
       {

--- a/CD4.AstmInterface/Model/Settings.cs
+++ b/CD4.AstmInterface/Model/Settings.cs
@@ -7,8 +7,6 @@ namespace CD4.AstmInterface.Model
     public class Settings
     {
         private Properties.Settings settings;
-        private string driverPath;
-
         public Settings()
         {
             settings = new Properties.Settings();
@@ -116,13 +114,43 @@ namespace CD4.AstmInterface.Model
 
         #endregion
 
+        #region Orders
+        [Category("Test Order Settings")]
+        public string IncomingPath
+        {
+            get => settings.IncomingPath;
+            set => settings.IncomingPath = value;
+        }
+
+        [Category("Test Order Settings")]
+        public string OrderControlFileExtension
+        {
+            get => settings.OrderControlFileExtension;
+            set => settings.OrderControlFileExtension = value;
+        }
+
+        [Category("Test Order Settings")]
+        public string OrderDataFileExtension 
+        { 
+            get => settings.OrderDataFileExtension; 
+            set => settings.OrderDataFileExtension = value; 
+        }
+
+        #endregion
+
         #region Rules Engine
         [Category("Rules Engine")]
-        public string AnalyserName 
+        public string AnalyserName
         {
             get => settings.AnalyserName;
             set => settings.AnalyserName = value;
         }
         #endregion
+
+        public string SenderName
+        {
+            get => settings.SenderName;
+            set => settings.SenderName = value;
+        }
     }
 }

--- a/CD4.AstmInterface/Program.cs
+++ b/CD4.AstmInterface/Program.cs
@@ -1,6 +1,7 @@
 using CD4.AstmInterface.View;
 using CD4.AstmInterface.ViewModel;
 using CD4.DataLibrary.DataAccess;
+using CD4.ResultsInterface.Common.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -25,6 +26,7 @@ namespace CD4.AstmInterface
                                //Register all your services here
                                services.AddScoped<MainView>();
                                services.AddScoped<MainViewModel>();
+                               services.AddTransient<IExportService, ExportService>();
                                services.AddTransient<IScriptDataAccess, ScriptDataAccess>();
                            }).ConfigureLogging(logBuilder =>
                            {

--- a/CD4.AstmInterface/Properties/Settings.Designer.cs
+++ b/CD4.AstmInterface/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CD4.AstmInterface.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -188,6 +188,54 @@ namespace CD4.AstmInterface.Properties {
             }
             set {
                 this["AnalyserName"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("CD4 LIMS")]
+        public string SenderName {
+            get {
+                return ((string)(this["SenderName"]));
+            }
+            set {
+                this["SenderName"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("C:\\Export")]
+        public string IncomingPath {
+            get {
+                return ((string)(this["IncomingPath"]));
+            }
+            set {
+                this["IncomingPath"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("ook")]
+        public string OrderControlFileExtension {
+            get {
+                return ((string)(this["OrderControlFileExtension"]));
+            }
+            set {
+                this["OrderControlFileExtension"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("ord")]
+        public string OrderDataFileExtension {
+            get {
+                return ((string)(this["OrderDataFileExtension"]));
+            }
+            set {
+                this["OrderDataFileExtension"] = value;
             }
         }
     }

--- a/CD4.AstmInterface/Properties/Settings.settings
+++ b/CD4.AstmInterface/Properties/Settings.settings
@@ -44,5 +44,17 @@
     <Setting Name="AnalyserName" Type="System.String" Scope="User">
       <Value Profile="(Default)">Analyser01</Value>
     </Setting>
+    <Setting Name="SenderName" Type="System.String" Scope="User">
+      <Value Profile="(Default)">CD4 LIMS</Value>
+    </Setting>
+    <Setting Name="IncomingPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)">C:\Export</Value>
+    </Setting>
+    <Setting Name="OrderControlFileExtension" Type="System.String" Scope="User">
+      <Value Profile="(Default)">ook</Value>
+    </Setting>
+    <Setting Name="OrderDataFileExtension" Type="System.String" Scope="User">
+      <Value Profile="(Default)">ord</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/CD4.AstmInterface/ViewModel/MainViewModel.cs
+++ b/CD4.AstmInterface/ViewModel/MainViewModel.cs
@@ -52,7 +52,7 @@ namespace CD4.AstmInterface.ViewModel
 
             _logger.Info("Application startup... loaded settings");
 
-            Initialize += RunInitalze;
+            Initialize += RunInitalize;
             ResultsReadyForExport += ExportResults;
             OnRequireInterpretation += MainViewModel_OnRequireInterpretation;
             OnQueryReceived += MainViewModel_OnQueryReceived;
@@ -81,7 +81,7 @@ namespace CD4.AstmInterface.ViewModel
                 //initiate sending a response to analyser that there is no order for the sample
                 //log the error
                 _logger.Error($"An error occured while trying to fetch order for analyser query: {query}");
-                _logger.Error(ex.Message+"\n"+ex.StackTrace);
+                _logger.Error(ex.Message + "\n" + ex.StackTrace);
             }
         }
 
@@ -120,7 +120,7 @@ namespace CD4.AstmInterface.ViewModel
 
         }
 
-        private async void RunInitalze(object sender, EventArgs e)
+        private async void RunInitalize(object sender, EventArgs e)
         {
             await LoadAndInitializeScript();
             await InitializeAstmAsync();
@@ -285,6 +285,7 @@ namespace CD4.AstmInterface.ViewModel
                     break;
                 case LisRecordType.Query:
                     var query = (QueryRecord)e.ReceivedRecord;
+                    query.UserFieldNumberTwo = Settings.AnalyserName;
                     OnQueryReceived?.Invoke(this, query);
                     break;
                 case LisRecordType.Terminator:

--- a/CD4.AstmInterface/ViewModel/MainViewModel.cs
+++ b/CD4.AstmInterface/ViewModel/MainViewModel.cs
@@ -41,13 +41,13 @@ namespace CD4.AstmInterface.ViewModel
         private event EventHandler Initialize;
         private event EventHandler<InterfaceResultsModel> OnRequireInterpretation;
 
-        public MainViewModel(IScriptDataAccess scriptDataAccess)
+        public MainViewModel(IScriptDataAccess scriptDataAccess, IExportService exportService)
         {
             _logger = LoggerFactory.GetLogger(typeof(MainViewModel));
             _scriptDataAccess = scriptDataAccess;
             Settings = new Model.Settings();
             _interfaceResults = new List<InterfaceResultsModel>();
-            _exportService = new ExportService();
+            _exportService = exportService;
             _queryResponseBuffer = new List<OrderRecord>();
 
             _logger.Info("Application startup... loaded settings");

--- a/CD4.Data/CD4.Data.sqlproj
+++ b/CD4.Data/CD4.Data.sqlproj
@@ -313,6 +313,8 @@
     <Build Include="dbo\StoredProcedures\usp_GetBarcodesForEpisode.sql" />
     <Build Include="dbo\StoredProcedures\usp_CollectAllSamplesForEpisode.sql" />
     <Build Include="dbo\StoredProcedures\usp_GetAnalysisReportForEpisode.sql" />
+    <Build Include="dbo\StoredProcedures\usp_GetAllAcceptedTestOrdersForAnalyser.sql" />
+    <Build Include="dbo\StoredProcedures\usp_GetAllAnalyserSpecificAcceptedTestOrdersForSample.sql" />
   </ItemGroup>
   <ItemGroup>
     <RefactorLog Include="CD4.Data.refactorlog" />

--- a/CD4.Data/dbo/StoredProcedures/usp_GetAllAcceptedTestOrdersForAnalyser.sql
+++ b/CD4.Data/dbo/StoredProcedures/usp_GetAllAcceptedTestOrdersForAnalyser.sql
@@ -1,0 +1,120 @@
+﻿CREATE PROCEDURE [dbo].[usp_GetAllAcceptedTestOrdersForAnalyser]
+	@AnalyserName varchar(50),
+	@UsersId int
+AS
+BEGIN
+
+DECLARE @AnalyserId int  = 0;
+DECLARE @ReceivedStatusId int = 3;
+DECLARE @ProcessingStatusId int = 6;
+DECLARE @TestTrackingId int  = 3;
+DECLARE @Username varchar(50);
+
+DECLARE @SamplesWithStatusChange TABLE([Cin] varchar(50)) -- to enable the recording sample tracking history
+DECLARE @Orders TABLE 
+(
+	[Download] varchar(50),
+	[Sid] varchar(50),
+	[SamplePriority] bit,
+	[TestPriority] bit,
+	[ResultId] int,
+	[EpisodeNumber] varchar(15),
+	[Age] varchar(20),
+	[FullName] varchar(100),
+	[NidPp] varchar(50),
+	[Birthdate] Date,
+	[Address] varchar(100)
+);
+
+SELECT @AnalyserId = [Id] FROM [dbo].[Analyser] WHERE [Description] = @AnalyserName;
+SELECT @Username = [UserName] FROM [dbo].[Users] WHERE [Id] = @UsersId;
+
+INSERT INTO @Orders
+SELECT
+	[cm].[Download],
+	[r].[Sample_Cin] AS [Sid],
+	[s].[IsStat] AS [SamplePriority],
+	[r].[IsStat] AS [TestPriority],
+	[r].[Id] as [ResultId],
+	[ar].[EpisodeNumber],
+	[ar].[Age],
+	[p].[FullName],
+	[p].[NidPp],
+	[p].[Birthdate],
+	[p].[Address]
+FROM [dbo].[ChannelMap] [cm]
+INNER JOIN [dbo].[Result] [r] ON [cm].[TestId] = [r].[TestId]
+INNER JOIN [dbo].[Sample] [s] ON [s].[Cin]  = [r].[Sample_Cin]
+INNER JOIN [dbo].[AnalysisRequest] [ar] ON [ar].[Id] = [s].[AnalysisRequestId]
+INNER JOIN [dbo].[Patient] [p] ON [p].[Id] = [ar].[PatientId]
+INNER JOIN [dbo].[ResultTracking] [rt] ON [r].[Id] = [rt].[ResultId]
+WHERE [rt].[StatusId] = @ReceivedStatusId
+  AND [cm].[AnalyserId] = @AnalyserId
+  AND [cm].[Enabled] = 1;
+  
+  -- Sample and result status management
+  --========================================
+  --update sample to processing
+UPDATE [dbo].[SampleTracking]
+SET StatusId = @ProcessingStatusId,
+	UsersId = @UsersId
+OUTPUT INSERTED.[SampleCin] INTO @SamplesWithStatusChange
+WHERE
+	[StatusId] = @ReceivedStatusId AND 
+	SampleCin IN 
+			(SELECT DISTINCT([Sid]) AS [SampleCin] FROM @Orders);
+
+  --update result status
+UPDATE [dbo].[ResultTracking]
+SET StatusId = @ProcessingStatusId,
+	UsersId = @UsersId
+WHERE ResultId IN 
+(
+	SELECT [ResultId] FROM @Orders
+);
+ 	
+	-- Tracking history - test
+INSERT INTO [dbo].[TrackingHistory] ([TrackingType],[ResultId],[StatusId],[UsersId])
+SELECT @TestTrackingId,[ResultId],@ReceivedStatusId,@UsersId
+FROM @Orders;
+	-- Tracking history - test
+INSERT INTO [dbo].[TrackingHistory] ([TrackingType],[SampleCin],[StatusId],[UsersId])
+SELECT @TestTrackingId,[Cin],@ReceivedStatusId,@UsersId
+FROM @SamplesWithStatusChange;
+
+  --Audit trail
+  --====================
+
+INSERT INTO [dbo].[AuditTrail]([Cin],[AuditTypeId],[StatusId],[Details])
+SELECT DISTINCT([Sid]), 
+	   @TestTrackingId
+	  ,@ReceivedStatusId
+	  ,CONCAT('Orders: ',STRING_AGG([Download],'|'),' downloaded to analyser interface: ', @AnalyserName, ' by ',@Username)
+FROM @Orders
+GROUP BY [Sid];
+
+  --return orders
+  --====================
+  SELECT 
+	 STRING_AGG([Download],'|') AS [Download]
+	,[Sid]
+	,[SamplePriority]
+	,[TestPriority]
+	,[EpisodeNumber]
+	,[Age]
+	,[FullName]
+	,[NidPp]
+	,[Birthdate]
+	,[Address]
+ FROM @Orders
+ GROUP BY
+	 [Sid]
+	,[SamplePriority]
+	,[TestPriority]
+	,[EpisodeNumber]
+	,[Age]
+	,[FullName]
+	,[NidPp]
+	,[Birthdate]
+	,[Address]
+END

--- a/CD4.Data/dbo/StoredProcedures/usp_GetAllAnalyserSpecificAcceptedTestOrdersForSample.sql
+++ b/CD4.Data/dbo/StoredProcedures/usp_GetAllAnalyserSpecificAcceptedTestOrdersForSample.sql
@@ -1,0 +1,123 @@
+﻿CREATE PROCEDURE [dbo].[usp_GetAllAnalyserSpecificAcceptedTestOrdersForSample]
+	@Sid varchar(50),
+	@AnalyserName varchar(50),
+	@UsersId int
+AS
+BEGIN
+
+-- Variables
+DECLARE @AnalyserId int  = 0;
+DECLARE @ReceivedStatusId int = 3;
+DECLARE @ProcessingStatusId int = 6;
+DECLARE @TestTrackingId int  = 3;
+DECLARE @Username varchar(50);
+DECLARE @SamplesWithStatusChange TABLE([Cin] varchar(50)) -- to enable the recording sample tracking history
+DECLARE @Orders TABLE 
+(
+	[Download] varchar(50),
+	[Sid] varchar(50),
+	[SamplePriority] bit,
+	[TestPriority] bit,
+	[ResultId] int,
+	[EpisodeNumber] varchar(15),
+	[Age] varchar(20),
+	[FullName] varchar(100),
+	[NidPp] varchar(50),
+	[Birthdate] Date,
+	[Address] varchar(100)
+);
+
+SELECT @AnalyserId = [Id] FROM [dbo].[Analyser] WHERE [Description] = @AnalyserName;
+SELECT @Username = [UserName] FROM [dbo].[Users] WHERE [Id] = @UsersId;
+
+-- fetch the actual orders
+INSERT INTO @Orders
+SELECT 
+	[cm].[Download],
+	[r].[Sample_Cin] AS [Sid],
+	[s].[IsStat] AS [SamplePriority],
+	[r].[IsStat] AS [TestPriority],
+	[r].[Id] as [ResultId],
+	[ar].[EpisodeNumber],
+	[ar].[Age],
+	[p].[FullName],
+	[p].[NidPp],
+	[p].[Birthdate],
+	[p].[Address]
+FROM [dbo].[ChannelMap] [cm]
+INNER JOIN [dbo].[Result] [r] ON [cm].[TestId] = [r].[TestId]
+INNER JOIN [dbo].[Sample] [s] ON [s].[Cin]  = [r].[Sample_Cin]
+INNER JOIN [dbo].[AnalysisRequest] [ar] ON [ar].[Id] = [s].[AnalysisRequestId]
+INNER JOIN [dbo].[Patient] [p] ON [p].[Id] = [ar].[PatientId]
+INNER JOIN [dbo].[ResultTracking] [rt] ON [r].[Id] = [rt].[ResultId]
+WHERE [rt].[StatusId] = 3
+  AND [r].[Sample_Cin] = @Sid
+  AND [cm].[AnalyserId] = @AnalyserId
+  AND [cm].[Enabled] = 1;
+
+  -- Sample and result status management
+  --========================================
+  --update sample to processing
+UPDATE [dbo].[SampleTracking]
+SET StatusId = @ProcessingStatusId,
+	UsersId = @UsersId
+OUTPUT INSERTED.[SampleCin] INTO @SamplesWithStatusChange
+WHERE
+	[StatusId] = @ReceivedStatusId AND 
+	SampleCin IN 
+			(SELECT DISTINCT([Sid]) AS [SampleCin] FROM @Orders);
+
+  --update result status
+UPDATE [dbo].[ResultTracking]
+SET StatusId = @ProcessingStatusId,
+	UsersId = @UsersId
+WHERE ResultId IN 
+(
+	SELECT [ResultId] FROM @Orders
+);
+
+	-- Tracking history - test
+INSERT INTO [dbo].[TrackingHistory] ([TrackingType],[ResultId],[StatusId],[UsersId])
+SELECT @TestTrackingId,[ResultId],@ReceivedStatusId,@UsersId
+FROM @Orders;
+	-- Tracking history - test
+INSERT INTO [dbo].[TrackingHistory] ([TrackingType],[SampleCin],[StatusId],[UsersId])
+SELECT @TestTrackingId,[Cin],@ReceivedStatusId,@UsersId
+FROM @SamplesWithStatusChange;
+
+  --Audit trail
+  --====================
+
+INSERT INTO [dbo].[AuditTrail]([Cin],[AuditTypeId],[StatusId],[Details])
+SELECT DISTINCT([Sid]), 
+	   @TestTrackingId
+	  ,@ReceivedStatusId
+	  ,CONCAT('Analyser: ',@AnalyserName,' requested orders for: ',@Sid,'. ',STRING_AGG([Download],'|'),' downloaded to analyser by ',@Username)
+FROM @Orders
+GROUP BY [Sid];
+
+  --return orders
+  --====================
+  SELECT 
+	 STRING_AGG([Download],'|') AS [Download]
+	,[Sid]
+	,[SamplePriority]
+	,[TestPriority]
+	,[EpisodeNumber]
+	,[Age]
+	,[FullName]
+	,[NidPp]
+	,[Birthdate]
+	,[Address]
+ FROM @Orders
+ GROUP BY
+	 [Sid]
+	,[SamplePriority]
+	,[TestPriority]
+	,[EpisodeNumber]
+	,[Age]
+	,[FullName]
+	,[NidPp]
+	,[Birthdate]
+	,[Address]
+END

--- a/CD4.Data/dbo/StoredProcedures/usp_UpdateTestById.sql
+++ b/CD4.Data/dbo/StoredProcedures/usp_UpdateTestById.sql
@@ -42,7 +42,7 @@ BEGIN
 	  , [t].[Code]
 	  , [t].[Reportable] AS [IsReportable]
 	  , [t].[DefaultCommented]
-	  , [t].[Sortorder]
+	  , [t].[SortOrder]
 	  , [t].[PrimaryHeader]
 	  , [t].[SecondaryHeader]
 	FROM [dbo].[Test] [t]

--- a/CD4.Data/dbo/Tables/ChannelMap.sql
+++ b/CD4.Data/dbo/Tables/ChannelMap.sql
@@ -6,6 +6,7 @@
     [Upload] VARCHAR(50) NOT NULL, 
     [Unit] VARCHAR(50) NOT NULL, 
     [AnalyserId] INT NOT NULL, 
+    [Enabled] BIT NOT NULL DEFAULT 1, -- only checked while downloading orders in download or query mode. result interface from analyser should not be effected.
     CONSTRAINT [FK_ChannelMap_Test] FOREIGN KEY ([TestId]) REFERENCES [dbo].[Test]([Id]), 
     CONSTRAINT [FK_ChannelMap_Analyser] FOREIGN KEY ([AnalyserId]) REFERENCES [dbo].[Analyser]([Id])
 )

--- a/CD4.Data/dbo/Tables/RequestTracking.sql
+++ b/CD4.Data/dbo/Tables/RequestTracking.sql
@@ -9,3 +9,8 @@
     CONSTRAINT [FK_RequestTracking_Status] FOREIGN KEY ([StatusId]) REFERENCES [dbo].[Status]([Id]), 
     CONSTRAINT [FK_RequestTracking_Users] FOREIGN KEY ([UsersId]) REFERENCES [dbo].[Users]([Id])
 )
+GO
+CREATE NONCLUSTERED INDEX [ResultTracking_StatusId_ResultId]
+ON [dbo].[ResultTracking] ([StatusId])
+INCLUDE ([ResultId])
+GO

--- a/CD4.DataLibrary/CD4.DataLibrary.csproj
+++ b/CD4.DataLibrary/CD4.DataLibrary.csproj
@@ -106,6 +106,8 @@
     <Compile Include="DataAccess\GlobalSettingsDataAccess.cs" />
     <Compile Include="DataAccess\HmsLinkDataAccess.cs" />
     <Compile Include="DataAccess\IHmsLinkDataAccess.cs" />
+    <Compile Include="DataAccess\IOrderDownloadDataAccess.cs" />
+    <Compile Include="DataAccess\OrderDownloadDataAccess.cs" />
     <Compile Include="Models\HmsLinkDataModel.cs" />
     <Compile Include="DataAccess\IAnalysisRequestDataAccess.cs" />
     <Compile Include="DataAccess\IAssayDataAccess.cs" />
@@ -170,6 +172,7 @@
     <Compile Include="Models\GenericModelAndListModel.cs" />
     <Compile Include="Models\GlobalSettingsModel.cs" />
     <Compile Include="Models\NdaTrackingModel.cs" />
+    <Compile Include="Models\OrdersDownloadModel.cs" />
     <Compile Include="Models\ResultDataTypeModel.cs" />
     <Compile Include="Models\SampleTypeModel.cs" />
     <Compile Include="Models\ScientistModel.cs" />

--- a/CD4.DataLibrary/Config.json
+++ b/CD4.DataLibrary/Config.json
@@ -2,7 +2,7 @@
   "ConnectionName": [
     {
       "Name": "CD4Data",
-      "ConnectionString": "Server=localhost,10433;Database=CD4Data.Staging.ASMH;User Id=sa;Password=Bismillah.123!;",
+      "ConnectionString": "Server=localhost,10433;Database=CD4Data;User Id=sa;Password=Bismillah.123!;",
       "Provider": "System.Data.SqlClient"
     },
     {

--- a/CD4.DataLibrary/DataAccess/IOrderDownloadDataAccess.cs
+++ b/CD4.DataLibrary/DataAccess/IOrderDownloadDataAccess.cs
@@ -1,0 +1,13 @@
+﻿using CD4.DataLibrary.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CD4.DataLibrary.DataAccess
+{
+    public interface IOrderDownloadDataAccess
+    {
+        Task<List<OrdersDownloadModel>> DownloadAllOrdersForAnalyserAsync(string analyserName, int usersId);
+        Task<List<OrdersDownloadModel>> DownloadAllAnalyserSpecificOrdersForQueriedSampleAsync(string analyserName, string sid, int usersId);
+
+    }
+}

--- a/CD4.DataLibrary/DataAccess/OrderDownloadDataAccess.cs
+++ b/CD4.DataLibrary/DataAccess/OrderDownloadDataAccess.cs
@@ -1,0 +1,39 @@
+﻿using CD4.DataLibrary.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CD4.DataLibrary.DataAccess
+{
+    public class OrderDownloadDataAccess : DataAccessBase, IOrderDownloadDataAccess
+    {
+        public async Task<List<OrdersDownloadModel>> DownloadAllOrdersForAnalyserAsync(string analyserName, int usersId)
+        {
+            var parameters = new { AnalyserName = analyserName, UsersId = usersId };
+            try
+            {
+                var storedProcedure = "[dbo].[usp_GetAllAcceptedTestOrdersForAnalyser]";
+                return await LoadDataWithParameterAsync<OrdersDownloadModel, dynamic>(storedProcedure, parameters);
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+
+        }
+        public async Task<List<OrdersDownloadModel>> DownloadAllAnalyserSpecificOrdersForQueriedSampleAsync(string analyserName, string sid, int usersId)
+        {
+            var parameters = new { AnalyserName = analyserName, Sid = sid, UsersId = usersId };
+            try
+            {
+                var storedProcedure = "[dbo].[usp_GetAllAnalyserSpecificAcceptedTestOrdersForSample]";
+                return await LoadDataWithParameterAsync<OrdersDownloadModel, dynamic>(storedProcedure, parameters);
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+
+    }
+}

--- a/CD4.DataLibrary/Models/OrdersDownloadModel.cs
+++ b/CD4.DataLibrary/Models/OrdersDownloadModel.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CD4.DataLibrary.Models
+{
+    public class OrdersDownloadModel
+    {
+        public string Download { get; set; }
+        public string Sid { get; set; }
+        public bool SamplePriority { get; set; }
+        public bool TestPriority { get; set; }
+        public string EpisodeNumber { get; set; }
+        public string Age { get; set; }
+        public string Fullname { get; set; }
+        public string NidPp { get; set; }
+        public DateTime Birthdate { get; set; }
+        public string Address { get; set; }
+
+    }
+}

--- a/CD4.ResultsInterface.Common/CD4.ResultsInterface.Common.csproj
+++ b/CD4.ResultsInterface.Common/CD4.ResultsInterface.Common.csproj
@@ -1,8 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CD4.ResultsInterface.Common/Models/OrdersDownloadModel.cs
+++ b/CD4.ResultsInterface.Common/Models/OrdersDownloadModel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CD4.ResultsInterface.Common.Models
+{
+    public class OrdersDownloadModel
+    {
+        public string Download { get; set; }
+        public string Sid { get; set; }
+        public bool SamplePriority { get; set; }
+        public bool TestPriority { get; set; }
+        public string EpisodeNumber { get; set; }
+        public string Age { get; set; }
+        public string Fullname { get; set; }
+        public string NidPp { get; set; }
+        public DateTime Birthdate { get; set; }
+        public string Address { get; set; }
+
+    }
+}

--- a/CD4.ResultsInterface.Common/Services/ExportService.cs
+++ b/CD4.ResultsInterface.Common/Services/ExportService.cs
@@ -42,8 +42,42 @@ namespace CD4.ResultsInterface.Common.Services
             #endregion
 
             var exportData = JsonConvert.SerializeObject(dataList);
+
+            try
+            {
+                return await ExportAsync<bool>(exportData, basepath, extension, controlFileExtension);
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+        private async Task<bool> ExportAsync<T>(string jsonExportData, string basepath, string extension, string controlFileExtension)
+        {
+            #region NULL checks
+            if (string.IsNullOrEmpty(jsonExportData))
+            {
+                throw new ArgumentException($"'{nameof(jsonExportData)}' cannot be null or empty.", nameof(jsonExportData));
+            }
+
+            if (string.IsNullOrEmpty(basepath))
+            {
+                throw new ArgumentException($"'{nameof(basepath)}' cannot be null or empty.", nameof(basepath));
+            }
+
+            if (string.IsNullOrEmpty(extension))
+            {
+                throw new ArgumentException($"'{nameof(extension)}' cannot be null or empty.", nameof(extension));
+            }
+
+            if (string.IsNullOrEmpty(controlFileExtension))
+            {
+                throw new ArgumentException($"'{nameof(controlFileExtension)}' cannot be null or empty.", nameof(controlFileExtension));
+            }
+            #endregion
+
             var filenameWithoutExtension = $"{basepath}\\{DateTime.Now:yyyyMMdd_HHmmss_fffffff}";
-            byte[] result = Encoding.UTF8.GetBytes(exportData);
+            byte[] result = Encoding.UTF8.GetBytes(jsonExportData);
             try
             {
                 using (FileStream SourceStream = File.Open($"{filenameWithoutExtension}.{extension}", FileMode.OpenOrCreate))
@@ -103,6 +137,19 @@ namespace CD4.ResultsInterface.Common.Services
             #endregion
 
             _ = await ExportAsync(queryRecord, "C:\\Export", "qrd.json", "qok");
+        }
+
+        public async Task ExportJsonDataAsync(string jsonExportData, string basepath, string extension, string controlFileExtension)
+        {
+            try
+            {
+                await ExportAsync<bool>(jsonExportData, basepath, extension, controlFileExtension);
+            }
+            catch (Exception)
+            {
+
+                throw;
+            }
         }
     }
 }

--- a/CD4.ResultsInterface.Common/Services/ExportService.cs
+++ b/CD4.ResultsInterface.Common/Services/ExportService.cs
@@ -10,14 +10,38 @@ namespace CD4.ResultsInterface.Common.Services
 {
     public class ExportService : IExportService
     {
-        public async Task<bool> ExportToUploader(List<InterfaceResultsModel> interfaceResults, string basepath, string extension, string controlFileExtension)
+        private async Task<bool> ExportAsync<T>(List<T> dataList, string basepath, string extension, string controlFileExtension)
         {
-            if (interfaceResults.Count == 0)
+            #region NULL Checks
+
+            if (dataList is null)
+            {
+                throw new ArgumentNullException(nameof(dataList));
+            }
+
+            if (string.IsNullOrEmpty(basepath))
+            {
+                throw new ArgumentException($"'{nameof(basepath)}' cannot be null or empty.", nameof(basepath));
+            }
+
+            if (string.IsNullOrEmpty(extension))
+            {
+                throw new ArgumentException($"'{nameof(extension)}' cannot be null or empty.", nameof(extension));
+            }
+
+            if (string.IsNullOrEmpty(controlFileExtension))
+            {
+                throw new ArgumentException($"'{nameof(controlFileExtension)}' cannot be null or empty.", nameof(controlFileExtension));
+            }
+
+            if (dataList.Count == 0)
             {
                 return false;
             }
 
-            var exportData = JsonConvert.SerializeObject(interfaceResults);
+            #endregion
+
+            var exportData = JsonConvert.SerializeObject(dataList);
             var filenameWithoutExtension = $"{basepath}\\{DateTime.Now:yyyyMMdd_HHmmss_fffffff}";
             byte[] result = Encoding.UTF8.GetBytes(exportData);
             try
@@ -34,6 +58,51 @@ namespace CD4.ResultsInterface.Common.Services
             {
                 throw;
             }
+        }
+
+        public async Task<bool> ExportToUploaderAsync(List<InterfaceResultsModel> interfaceResults, string basepath, string extension, string controlFileExtension)
+        {
+            return await ExportAsync(interfaceResults, basepath, extension, controlFileExtension);
+        }
+
+        public async Task ExportQueryToOrderDownloaderAsync(List<string> jsonQueryRecord, string basepath, string extension, string controlFileExtension)
+        {
+            #region NULL Check
+            if (jsonQueryRecord is null)
+            {
+                throw new ArgumentNullException(nameof(jsonQueryRecord));
+            }
+
+            if (string.IsNullOrEmpty(basepath))
+            {
+                throw new ArgumentException($"'{nameof(basepath)}' cannot be null or empty.", nameof(basepath));
+            }
+
+            if (string.IsNullOrEmpty(extension))
+            {
+                throw new ArgumentException($"'{nameof(extension)}' cannot be null or empty.", nameof(extension));
+            }
+
+            if (string.IsNullOrEmpty(controlFileExtension))
+            {
+                throw new ArgumentException($"'{nameof(controlFileExtension)}' cannot be null or empty.", nameof(controlFileExtension));
+            }
+            #endregion
+
+            _ = await ExportAsync(jsonQueryRecord, basepath, extension, controlFileExtension);
+        }
+
+        public async Task ExportQueryToOrderDownloaderAsync(List<dynamic> queryRecord)
+        {
+            #region NULL Check
+            if (queryRecord is null)
+            {
+                throw new ArgumentNullException(nameof(queryRecord));
+            }
+
+            #endregion
+
+            _ = await ExportAsync(queryRecord, "C:\\Export", "qrd.json", "qok");
         }
     }
 }

--- a/CD4.ResultsInterface.Common/Services/IExportService.cs
+++ b/CD4.ResultsInterface.Common/Services/IExportService.cs
@@ -6,6 +6,7 @@ namespace CD4.ResultsInterface.Common.Services
 {
     public interface IExportService
     {
+        Task ExportJsonDataAsync(string jsonExportData, string basepath, string extension, string controlFileExtension);
         Task ExportQueryToOrderDownloaderAsync(List<string> jsonQueryRecord, string basepath, string extension, string controlFileExtension);
         Task ExportQueryToOrderDownloaderAsync(List<dynamic> queryRecord);
         Task<bool> ExportToUploaderAsync(List<InterfaceResultsModel> interfaceResults, string basepath, string extension, string controlFileExtension);

--- a/CD4.ResultsInterface.Common/Services/IExportService.cs
+++ b/CD4.ResultsInterface.Common/Services/IExportService.cs
@@ -6,6 +6,8 @@ namespace CD4.ResultsInterface.Common.Services
 {
     public interface IExportService
     {
-        Task<bool> ExportToUploader(List<InterfaceResultsModel> interfaceResults, string basepath, string extension, string controlFileExtension);
+        Task ExportQueryToOrderDownloaderAsync(List<string> jsonQueryRecord, string basepath, string extension, string controlFileExtension);
+        Task ExportQueryToOrderDownloaderAsync(List<dynamic> queryRecord);
+        Task<bool> ExportToUploaderAsync(List<InterfaceResultsModel> interfaceResults, string basepath, string extension, string controlFileExtension);
     }
 }

--- a/CD4.sln
+++ b/CD4.sln
@@ -39,7 +39,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CD4.BillingInterface.WebApi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CD4.ExcelInterface.QuantStudio5.Tests", "CD4.ExcelInterface.QuantStudio5.Tests\CD4.ExcelInterface.QuantStudio5.Tests.csproj", "{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CD4.AstmInterface.DownloaderService", "CD4.AstmInterface.DownloaderService\CD4.AstmInterface.DownloaderService.csproj", "{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CD4.AstmInterface.DownloaderService", "CD4.AstmInterface.DownloaderService\CD4.AstmInterface.DownloaderService.csproj", "{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -403,8 +403,8 @@ Global
 		{DEA1FD98-08A7-4C95-B97D-98C47A740FD2}.Release|ARM64.Build.0 = Release|Any CPU
 		{DEA1FD98-08A7-4C95-B97D-98C47A740FD2}.Release|x64.ActiveCfg = Release|x64
 		{DEA1FD98-08A7-4C95-B97D-98C47A740FD2}.Release|x64.Build.0 = Release|x64
-		{DEA1FD98-08A7-4C95-B97D-98C47A740FD2}.Release|x86.ActiveCfg = Release|Any CPU
-		{DEA1FD98-08A7-4C95-B97D-98C47A740FD2}.Release|x86.Build.0 = Release|Any CPU
+		{DEA1FD98-08A7-4C95-B97D-98C47A740FD2}.Release|x86.ActiveCfg = Release|x86
+		{DEA1FD98-08A7-4C95-B97D-98C47A740FD2}.Release|x86.Build.0 = Release|x86
 		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -423,28 +423,28 @@ Global
 		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|ARM64.Build.0 = Release|Any CPU
 		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|x64.ActiveCfg = Release|x64
 		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|x64.Build.0 = Release|x64
-		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|x86.ActiveCfg = Release|Any CPU
-		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|x86.Build.0 = Release|Any CPU
+		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|x86.ActiveCfg = Release|x86
+		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|x86.Build.0 = Release|x86
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|ARM.Build.0 = Debug|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|ARM64.ActiveCfg = Debug|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|ARM64.Build.0 = Debug|Any CPU
-		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x64.Build.0 = Debug|Any CPU
-		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x86.Build.0 = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x64.ActiveCfg = Debug|x64
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x64.Build.0 = Debug|x64
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x86.ActiveCfg = Debug|x86
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x86.Build.0 = Debug|x86
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|ARM.ActiveCfg = Release|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|ARM.Build.0 = Release|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|ARM64.ActiveCfg = Release|Any CPU
 		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|ARM64.Build.0 = Release|Any CPU
-		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x64.ActiveCfg = Release|Any CPU
-		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x64.Build.0 = Release|Any CPU
-		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x86.ActiveCfg = Release|Any CPU
-		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x86.Build.0 = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x64.ActiveCfg = Release|x64
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x64.Build.0 = Release|x64
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x86.ActiveCfg = Release|x86
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CD4.sln
+++ b/CD4.sln
@@ -39,6 +39,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CD4.BillingInterface.WebApi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CD4.ExcelInterface.QuantStudio5.Tests", "CD4.ExcelInterface.QuantStudio5.Tests\CD4.ExcelInterface.QuantStudio5.Tests.csproj", "{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CD4.AstmInterface.DownloaderService", "CD4.AstmInterface.DownloaderService\CD4.AstmInterface.DownloaderService.csproj", "{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -423,6 +425,26 @@ Global
 		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|x64.Build.0 = Release|x64
 		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|x86.ActiveCfg = Release|Any CPU
 		{68AB0F5C-20E1-4CA9-B23B-EFC151A75A8A}.Release|x86.Build.0 = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x64.Build.0 = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Debug|x86.Build.0 = Debug|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|ARM.Build.0 = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|ARM64.Build.0 = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x64.ActiveCfg = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x64.Build.0 = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x86.ActiveCfg = Release|Any CPU
+		{F1EB8309-E9EB-476C-B3F3-D9991FD68A46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Implemented the following features

### ASTM Interface
- ASTM interface can now export a query from analyser to Download service.
- ASTM interface can transmit test orders exported by Download to analyser.

### Downloader Service
- Can detect queries exported by ASTM Interface
- Can fetch orders for received queries(SIDs) from database for the specific analyser. If no orders are found, Exports an empty response.
- Can download ALL pending orders for an analyser

### Other Projects
Updated database and data layer to accommodate orders download by query mode and download mode.

> Query mode is better optimized on database. So always use query mode instead of download mode where possible. 